### PR TITLE
Keyboard a11y

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -866,7 +866,7 @@
 
                 if (isValid(targetMoment)) {
                     date = targetMoment;
-                    //viewDate = date.clone(); // TODO this doesn't work right on first use
+                    viewDate = date.clone(); // TODO this doesn't work right on first use
                     input.val(date.format(actualFormat));
                     element.data('date', date.format(actualFormat));
                     unset = false;

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -931,7 +931,7 @@
                     date: date.clone()
                 });
 
-                input.blur();
+                input.focus();
 
                 currentViewMode = 0;
                 viewDate = date.clone();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -104,8 +104,8 @@
                 37: 'left',
                 'right': 39,
                 39: 'right',
-                'tab': 9,
-                9: 'tab',
+                // 'tab': 9,
+                // 9: 'tab',
                 'escape': 27,
                 27: 'escape',
                 'enter': 13,
@@ -1257,7 +1257,24 @@
                 return (widget ? hide() : show());
             },
 
+            isInKeyMap = function (key) {
+                var isInKeyMap = false,
+                    index;
+
+                for (index in keyMap) {
+                    if (keyMap.hasOwnProperty(index) && keyMap[index] === key) {
+                        isInKeyMap = true;
+                        break;
+                    }
+                }
+
+                return isInKeyMap;
+            },
+
             keydown = function (e) {
+                if (!widget) {
+                    return;
+                }
                 var handler = null,
                     index,
                     index2,
@@ -1268,8 +1285,9 @@
                     allModifiersPressed,
                     pressed = 'p';
 
-                keyState[currentKey] = pressed;
-
+                if (isInKeyMap(currentKey)) {
+                    keyState[currentKey] = pressed;
+                }
                 for (index in keyState) {
                     if (keyState.hasOwnProperty(index) && keyState[index] === pressed) {
                         pressedKeys.push(index);
@@ -1306,7 +1324,12 @@
             },
 
             keyup = function (e) {
-                keyState[e.which] = 'r';
+                if (!widget) {
+                    return;
+                }
+                if (isInKeyMap(e.which)) {
+                    keyState[e.which] = 'r';
+                }
                 e.stopPropagation();
                 e.preventDefault();
             },
@@ -2517,7 +2540,7 @@
             },
             down: function (widget) {
                 if (!widget) {
-                    this.show();
+                    // this.show();
                     return;
                 }
                 var d = this.date() || this.getMoment();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -118,6 +118,8 @@
                 16: 'shift',
                 'control': 17,
                 17: 'control',
+                'alt': 18,
+                18: 'alt',
                 'space': 32,
                 32: 'space',
                 't': 84,


### PR DESCRIPTION
The PR focuses on keyboard accessibility of the bootstrap-datetimepicker.
It includes @petester42 's keybinding fixes and a few tweaks included not to loose overall focus when keyboard navigating the datetimepicker.

I've spoken to both @petester42  and @raphaelgera  about the keyboard navigating when both date and time picker is visible at the same time. This PR does not solve that. Keybindings (`options.keyBinds`) can be customized by configuration of the datetimepicker, so that's not included in core fork of the datetimepicker.

My next PR will focus on markup accessibility (using `buttons` instead of `td`'s and describing what's happening with `aria` tags). That PR will probably be submitted as a PR to the `Eonasdan` repository.

Any feedback is appreciated. If you don't have any comments, please leave a 👍 so I know I have your acceptance to merge.