### PR TITLE
Fixed keybind group issue, if a group is deleted

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1607,14 +1607,16 @@
                         }
                     }
 
-                    keyBindings = activeKeybindingCategories.reduce(function (allBindings, bindingsToAdd) {
-                        var allKeysToAdd = Object.keys(bindingsToAdd),
-                        i;
-                        for (i = 0; i < allKeysToAdd.length; i++) {
-                            allBindings[allKeysToAdd[i]] = bindingsToAdd[allKeysToAdd[i]];
-                        }
-                        return allBindings;
-                    }, {});
+                    keyBindings = activeKeybindingCategories
+                        .filter(function (keyBindingGroup) { return !!keyBindingGroup; })
+                        .reduce(function (allBindings, bindingsToAdd) {
+                            var allKeysToAdd = Object.keys(bindingsToAdd),
+                            i;
+                            for (i = 0; i < allKeysToAdd.length; i++) {
+                                allBindings[allKeysToAdd[i]] = bindingsToAdd[allKeysToAdd[i]];
+                            }
+                            return allBindings;
+                        }, {});
 
                     keyBindingCache[area] = keyBindings;
                 }

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1608,7 +1608,9 @@
                     }
 
                     keyBindings = activeKeybindingCategories
-                        .filter(function (keyBindingGroup) { return !!keyBindingGroup; })
+                        .filter(function (keyBindingGroup) {
+                            return !!keyBindingGroup;
+                        })
                         .reduce(function (allBindings, bindingsToAdd) {
                             var allKeysToAdd = Object.keys(bindingsToAdd),
                             i;

--- a/test/publicApiSpec.js
+++ b/test/publicApiSpec.js
@@ -1214,6 +1214,13 @@ describe('Public API method tests', function () {
             expect(defaultKeyBinds.secondpicker).toBeDefined();
         });
 
+        it('should work even if groups are missing', function () {
+            dtp.keyBinds({});
+            expect(function () {
+                dpHelper.keyDown(dtpElement, { which: dpHelper.Key.down });
+            }).not.toThrow();
+        });
+
         describe('trigger keyBinds correctly based on context', function () {
             var inputDown,
                 generalTab,


### PR DESCRIPTION
If you delete a group, such as `input` in the keyBinds option object the `keydown` will throw an error `TypeError: Requested keys of a value that is not an object..`.

This PR fixes that issue, and tests the expected behaviour.