### PR TITLE
Fix issue with date picker not disappearing when clicking outside of it

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1124,6 +1124,15 @@
                 }
             },
 
+            onDocumentMouseUp = function (e) {
+                if (
+                    !widget.is(e.target) &&
+                    widget.has(e.target).length === 0
+                ) {
+                    hide();
+                }
+            },
+
             /**
              * Hides the widget. Possibly will emit dp.hide
              */
@@ -1157,6 +1166,8 @@
                     'keydown': keydown,
                     'keyup': keyup
                 });
+
+                $('body', document).off('mouseup', onDocumentMouseUp);
 
                 widget.remove();
                 widget = false;
@@ -1522,9 +1533,12 @@
                     'keyup': keyup
                 });
 
+                $('body', document).on('mouseup', onDocumentMouseUp);
+
                 notifyEvent({
                     type: 'dp.show'
                 });
+
                 return picker;
             },
 


### PR DESCRIPTION
Fixes issue with date picker not disappearing when clicking outside of the date picker.
Before the datepicker would hide when the input field would blur, however that is no longer the case with the new focus shift.