### PR TITLE
Fixes for a couple of accessibility issues

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -854,6 +854,7 @@
                 daysViewHeader.eq(1).find('span.picker-switch-label').attr('title', options.tooltips.selectMonth);
                 daysViewHeader.eq(2).find('span').attr('title', options.tooltips.nextMonth);
 
+console.log('fillDate');
                 daysView.find('.disabled').removeClass('disabled');
                 daysViewHeader.eq(1).find('span.picker-switch-label').text(viewDate.format(options.dayViewHeaderFormat));
                 daysViewHeader.eq(1).find('span.hidden').text(viewDate.format(options.dayViewHeaderFormat) + ', ' + viewDate.format('D'));
@@ -1128,6 +1129,18 @@
             },
 
             onDocumentMouseUp = function (e) {
+                if (
+                    component &&
+                    !(
+                        component.is(e.target) &&
+                        component.has(e.target).length === 0
+                    )
+                ) {
+                    // Do not hide, if user is clicking on the 'open date picker' button
+                    // That will trigger a hide, and then show (like it's responding).
+                    return;
+                }
+
                 if (
                     !widget.is(e.target) &&
                     widget.has(e.target).length === 0

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -198,7 +198,7 @@
                 return (isEnabled('y') || isEnabled('M') || isEnabled('d'));
             },
 
-            getHeadTemplate = function (labelId) {
+            getHeadTemplate = function () {
                 return $('<thead>')
                     .append($('<tr>')
                         .append($('<th>').addClass('prev').attr('data-action', 'previous')
@@ -210,11 +210,6 @@
                             .attr('data-action', 'pickerSwitch')
                             .append($('<span>')
                                 .addClass('picker-switch-label')
-                                )
-                            .append($('<span>')
-                                .addClass('hidden')
-                                .attr('id', labelId)
-                                .attr('role', 'presentation')
                                 )
                             )
                         .append($('<th>').addClass('next').attr('data-action', 'next')
@@ -233,49 +228,37 @@
                     $('<div>').addClass('datepicker-days')
                         .append($('<table>')
                             .addClass('table-condensed')
-                            .attr('aria-labelledby', 'datepicker-days-label')
-                            .attr('aria-controls', 'datepicker-days-label')
-                            .attr('aria-live', 'assertive')
-                            .attr('aria-atomic', 'true')
+                            .attr('summary', options.tooltips.selectDate)
                             .attr('tabindex', 0)
                             .attr('role', 'application')
-                            .append(getHeadTemplate('datepicker-days-label'))
+                            .append(getHeadTemplate())
                             .append($('<tbody>'))
                             ),
                     $('<div>').addClass('datepicker-months')
                         .append($('<table>')
                             .addClass('table-condensed')
-                            .attr('aria-labelledby', 'datepicker-months-label')
-                            .attr('aria-controls', 'datepicker-months-label')
-                            .attr('aria-live', 'assertive')
-                            .attr('aria-atomic', 'true')
+                            .attr('summary', options.tooltips.selectMonth)
                             .attr('tabindex', 0)
                             .attr('role', 'application')
-                            .append(getHeadTemplate('datepicker-months-label'))
+                            .append(getHeadTemplate())
                             .append(contTemplate.clone())
                             ),
                     $('<div>').addClass('datepicker-years')
                         .append($('<table>')
                             .addClass('table-condensed')
-                            .attr('aria-labelledby', 'datepicker-years-label')
-                            .attr('aria-controls', 'datepicker-years-label')
-                            .attr('aria-live', 'assertive')
-                            .attr('aria-atomic', 'true')
+                            .attr('summary', options.tooltips.selectYear)
                             .attr('tabindex', 0)
                             .attr('role', 'application')
-                            .append(getHeadTemplate('datepicker-years-label'))
+                            .append(getHeadTemplate())
                             .append(contTemplate.clone())
                             ),
                     $('<div>').addClass('datepicker-decades')
                         .append($('<table>')
                             .addClass('table-condensed')
-                            .attr('aria-labelledby', 'datepicker-decades-label')
-                            .attr('aria-controls', 'datepicker-decades-label')
-                            .attr('aria-live', 'assertive')
-                            .attr('aria-atomic', 'true')
+                            .attr('summary', options.tooltips.selectDecade)
                             .attr('tabindex', 0)
                             .attr('role', 'application')
-                            .append(getHeadTemplate('datepicker-decades-label'))
+                            .append(getHeadTemplate())
                             .append(contTemplate.clone())
                             )
                 ];
@@ -336,19 +319,19 @@
                     .append($('<table>')
                         .addClass('table-condensed')
                         .attr('aria-labelledby', 'timepicker-time-label')
-                        .attr('aria-controls', 'timepicker-time-label')
-                        .attr('aria-live', 'assertive')
-                        .attr('aria-atomic', 'true')
                         .attr('role', 'application')
+                        .attr('summary', options.tooltips.selectTime)
                         .attr('tabindex', 0)
                         .append($('<thead>')
                             .append($('<tr>')
-                                .addClass('hidden')
+                                .addClass('pseudo-hidden')
                                 .append($('<th>')
                                     .attr('colspan', topRow.children().length)
                                     .append($('<span>')
                                         .attr('id', 'timepicker-time-label')
-                                        .attr('role', 'presentation')
+                                        .attr('role', 'alert')
+                                        .attr('aria-live', 'assertive')
+                                        .attr('aria-atomic', 'true')
                                         )
                                     )
                                 )
@@ -912,8 +895,9 @@
                     row.append($('<td>')
                         .attr('data-action', 'selectDay')
                         .attr('data-day', currentDate.format('L'))
-                        .addClass(clsNames.join(' '))
                         .attr('aria-selected', selectedDay ? 'true' : 'false')
+                        .attr('aria-label', currentDate.format('L'))
+                        .addClass(clsNames.join(' '))
                         .attr('id', 'date' + currentDate.format('YYYYMMDD'))
                         .text(currentDate.date())
                         );
@@ -1050,7 +1034,7 @@
                         timeLabel += ' ' + date.format('A');
                     }
 
-                    $timeLabel.text(timeLabel);
+                    $timeLabel.empty().text(timeLabel);
                 }
 
                 fillHours();

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -238,7 +238,7 @@
                             .attr('aria-live', 'assertive')
                             .attr('aria-atomic', 'true')
                             .attr('tabindex', 0)
-                            .attr('role', 'group')
+                            .attr('role', 'application')
                             .append(getHeadTemplate('datepicker-days-label'))
                             .append($('<tbody>'))
                             ),
@@ -250,6 +250,7 @@
                             .attr('aria-live', 'assertive')
                             .attr('aria-atomic', 'true')
                             .attr('tabindex', 0)
+                            .attr('role', 'application')
                             .append(getHeadTemplate('datepicker-months-label'))
                             .append(contTemplate.clone())
                             ),
@@ -261,6 +262,7 @@
                             .attr('aria-live', 'assertive')
                             .attr('aria-atomic', 'true')
                             .attr('tabindex', 0)
+                            .attr('role', 'application')
                             .append(getHeadTemplate('datepicker-years-label'))
                             .append(contTemplate.clone())
                             ),
@@ -272,6 +274,7 @@
                             .attr('aria-live', 'assertive')
                             .attr('aria-atomic', 'true')
                             .attr('tabindex', 0)
+                            .attr('role', 'application')
                             .append(getHeadTemplate('datepicker-decades-label'))
                             .append(contTemplate.clone())
                             )
@@ -336,7 +339,7 @@
                         .attr('aria-controls', 'timepicker-time-label')
                         .attr('aria-live', 'assertive')
                         .attr('aria-atomic', 'true')
-                        .attr('role', 'group')
+                        .attr('role', 'application')
                         .attr('tabindex', 0)
                         .append($('<thead>')
                             .append($('<tr>')
@@ -361,21 +364,21 @@
                         .append($('<table>')
                             .addClass('table-condensed')
                             .attr('aria-labelledby', 'timepicker-time-label')
-                            .attr('role', 'group')
+                            .attr('role', 'application')
                             .attr('tabindex', 0)
                             ),
                     minutesView = $('<div>').addClass('timepicker-minutes')
                         .append($('<table>')
                             .addClass('table-condensed')
                             .attr('aria-labelledby', 'timepicker-time-label')
-                            .attr('role', 'group')
+                            .attr('role', 'application')
                             .attr('tabindex', 0)
                             ),
                     secondsView = $('<div>').addClass('timepicker-seconds')
                         .append($('<table>')
                             .addClass('table-condensed')
                             .attr('aria-labelledby', 'timepicker-time-label')
-                            .attr('role', 'group')
+                            .attr('role', 'application')
                             .attr('tabindex', 0)
                             ),
                     ret = [getTimePickerMainTemplate()];

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -466,7 +466,7 @@
             },
 
             getTemplate = function () {
-                var template = $('<div>').addClass('bootstrap-datetimepicker-widget dropdown-menu').attr('role', 'application'),
+                var template = $('<div>').addClass('bootstrap-datetimepicker-widget dropdown-menu'),
                     dateView = $('<div>').addClass('datepicker').append(getDatePickerTemplate()),
                     timeView = $('<div>').addClass('timepicker').append(getTimePickerTemplate()),
                     content = $('<ul>').addClass('list-unstyled'),

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -854,7 +854,6 @@
                 daysViewHeader.eq(1).find('span.picker-switch-label').attr('title', options.tooltips.selectMonth);
                 daysViewHeader.eq(2).find('span').attr('title', options.tooltips.nextMonth);
 
-console.log('fillDate');
                 daysView.find('.disabled').removeClass('disabled');
                 daysViewHeader.eq(1).find('span.picker-switch-label').text(viewDate.format(options.dayViewHeaderFormat));
                 daysViewHeader.eq(1).find('span.hidden').text(viewDate.format(options.dayViewHeaderFormat) + ', ' + viewDate.format('D'));

--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1128,13 +1128,7 @@
             },
 
             onDocumentMouseUp = function (e) {
-                if (
-                    component &&
-                    !(
-                        component.is(e.target) &&
-                        component.has(e.target).length === 0
-                    )
-                ) {
+                if (component && (component.is(e.target) || component.has(e.target).length > 0)) {
                     // Do not hide, if user is clicking on the 'open date picker' button
                     // That will trigger a hide, and then show (like it's responding).
                     return;

--- a/src/less/_bootstrap-datetimepicker.less
+++ b/src/less/_bootstrap-datetimepicker.less
@@ -106,6 +106,24 @@
         box-shadow: none;
     }
 
+    .timepicker-picker {
+        tr.pseudo-hidden {
+            th {
+                height: 0;
+                line-height: 0;
+                overflow: hidden;
+                cursor: default;
+                padding: 0;
+
+                span {
+                    color: transparent;
+                    font-size: 1px;
+                    text-indent: -9999px;
+                }
+            }
+        }
+    }
+
     .timepicker-hour, .timepicker-minute, .timepicker-second {
         width: 54px;
         font-weight: bold;

--- a/src/sass/_bootstrap-datetimepicker.scss
+++ b/src/sass/_bootstrap-datetimepicker.scss
@@ -106,6 +106,24 @@ $bs-datetimepicker-text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25) !default;
         box-shadow: none;
     }
 
+    .timepicker-picker {
+        tr.pseudo-hidden {
+            th {
+                height: 0;
+                line-height: 0;
+                overflow: hidden;
+                cursor: default;
+                padding: 0;
+
+                span {
+                    color: transparent;
+                    font-size: 1px;
+                    text-indent: -9999px;
+                }
+            }
+        }
+    }
+
     .timepicker-hour, .timepicker-minute, .timepicker-second {
         width: 54px;
         font-weight: bold;


### PR DESCRIPTION
1) Instead of using role group for the focusable element, I switched to role application for more keyboard control.
2) Deprecated the `aria-live` tag on date picker table and added `aria-label`s on the selected elements themself.
3) To avoid reading the whole table in the time picker, I put the `aria-live` on the label itself, instead of the table. For that to work, I had to not have it be hidden (`display: none`).
4) `onDocumentClick` would close and then reopen, if clicking on a toggle button outside of the widget. Issue fixed.